### PR TITLE
Rename app from Scribe to Seeker

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,4 +1,4 @@
-name: "scribe"
+name: "seeker"
 
 services:
   rails-app:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://containers.dev/implementors/json_reference/.
 // For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
-  "name": "scribe",
+  "name": "seeker",
   "dockerComposeFile": "compose.yaml",
   "service": "rails-app",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,9 +64,9 @@ jobs:
       postgres:
         image: postgres:17.4-alpine
         env:
-          POSTGRES_DB: scribe_test
+          POSTGRES_DB: seeker_test
           POSTGRES_PASSWORD: sekret
-          POSTGRES_USER: scribe
+          POSTGRES_USER: seeker
         ports:
           - 5432:5432
         options: >-
@@ -85,7 +85,7 @@ jobs:
           --health-retries=3
     env:
       DB_PASSWORD: sekret
-      DB_USERNAME: scribe
+      DB_USERNAME: seeker
       RAILS_ENV: test
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Seeker
 
+[![test](https://github.com/thyword-study/seeker/actions/workflows/test.yml/badge.svg)](https://github.com/thyword-study/seeker/actions/workflows/test.yml) [![release](https://github.com/thyword-study/seeker/actions/workflows/release.yml/badge.svg?event=release)](https://github.com/thyword-study/seeker/actions/workflows/release.yml)
+
 ## Dependencies
 
 ### System

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scribe
+# Seeker
 
 ## Dependencies
 
@@ -53,9 +53,9 @@ for more details.
 Assuming you have a root user (with no password) ... first create the tables in
 the database by running `rails db:create`. This will create 2 databases:
 
-* `scribe_development` - used when running the app in development mode (ideal
+* `seeker_development` - used when running the app in development mode (ideal
   for testing locally).
-* `scribe_test` - used by the app when running the test suites.
+* `seeker_test` - used by the app when running the test suites.
 
 Then run the migrations by running `rails db:schema:load db:migrate` to create
 the database structure i.e. columns, indices in the table for you. You may also

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Scribe" %></title>
+    <title><%= content_for(:title) || "Seeker" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "Scribe",
+  "name": "Seeker",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "Scribe.",
+  "description": "Seeker.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ require "action_cable/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Scribe
+module Seeker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: scribe_production
+  channel_prefix: seeker_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,27 +23,27 @@ default: &default
 
 development:
   <<: *default
-  database: scribe_development
+  database: seeker_development
 
 test:
   <<: *default
-  database: scribe_test
+  database: seeker_test
 
 production:
   primary: &primary_production
     <<: *default
-    database: scribe_production
-    username: scribe
+    database: seeker_production
+    username: seeker
     password: <%= ENV["DB_PASSWORD"] %>
   cache:
     <<: *primary_production
-    database: scribe_production_cache
+    database: seeker_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: scribe_production_queue
+    database: seeker_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: scribe_production_cable
+    database: seeker_production_cable
     migrations_paths: db/cable_migrate

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 ---
 app:
-  name: Scribe
+  name: Seeker
 
 bible:
   defaults:


### PR DESCRIPTION
This pull request implements a comprehensive rebranding of the application from "Scribe" to "Seeker." The changes span across configuration files, documentation, and application code to reflect the new name consistently. Below is a summary of the most important changes, grouped by theme:

###

#### Application Name Update

* Updated the application name in `.devcontainer/compose.yaml` and `.devcontainer/devcontainer.json` to "Seeker".
* Renamed the module in `config/application.rb` from `Scribe` to `Seeker`.
* Changed the app name in `config/settings.yml` from `Scribe` to `Seeker`.

#### Database Configuration

* Updated database names and credentials in `config/database.yml` to use `seeker` instead of `scribe`.
* Adjusted test database settings in `.github/workflows/test.yml` to reflect the new name.

#### Documentation and Metadata

* Renamed the app in `README.md` and updated references to the database names.
* Updated the application title in `app/views/layouts/application.html.erb`.
* Adjusted the app name and description in `app/views/pwa/manifest.json.erb`.

#### Workflow Adjustments

* Capitalized workflow names in `.github/workflows/release.yml` and `.github/workflows/test.yml` for consistency.

#### Other Configuration

* Updated the Redis channel prefix in `config/cable.yml` to reflect the new name.