### PR TITLE
Add basic chapter pagination

### DIFF
--- a/app/models/bible/book.rb
+++ b/app/models/bible/book.rb
@@ -57,4 +57,18 @@ class Bible::Book < ApplicationRecord
   # Scopes
   scope :old_testament, -> { where(testament: "OT") }
   scope :new_testament, -> { where(testament: "NT") }
+
+  # Returns the number of the next book in the translation, or `nil` if the
+  # current book is the last one in the translation.
+  #
+  # @return [Integer, nil] The number of the next book, or `nil` if there is no
+  #   next book.
+  def next_number
+    if number == translation.books_count
+      nil
+    else
+      number + 1
+    end
+  end
+
 end

--- a/app/models/bible/book.rb
+++ b/app/models/bible/book.rb
@@ -71,4 +71,16 @@ class Bible::Book < ApplicationRecord
     end
   end
 
+  # Returns the number of the previous book in the translation, or `nil` if the
+  # current book is the first one in the translation.
+  #
+  # @return [Integer, nil] The number of the previous book, or `nil` if there is
+  #   no previous book.
+  def previous_number
+    if number == 1
+      nil
+    else
+      number - 1
+    end
+  end
 end

--- a/app/models/bible/chapter.rb
+++ b/app/models/bible/chapter.rb
@@ -95,6 +95,19 @@ class Bible::Chapter < ApplicationRecord
     end
   end
 
+  # Returns the number of the previous chapter in the book, or `nil` if the
+  # current chapter is the first one in the book.
+  #
+  # @return [Integer, nil] The number of the previous chapter, or `nil` if there
+  #   is no previous chapter.
+  def previous_number
+    if number == 1
+      nil
+    else
+      number - 1
+    end
+  end
+
   # Returns the title of the chapter in the format "Chapter <number>".
   #
   # @return [String] the formatted chapter title

--- a/app/models/bible/chapter.rb
+++ b/app/models/bible/chapter.rb
@@ -82,6 +82,19 @@ class Bible::Chapter < ApplicationRecord
     "#{book.title} #{number}"
   end
 
+  # Returns the number of the next chapter in the book, or `nil` if the current
+  # chapter is the last one in the book.
+  #
+  # @return [Integer, nil] The number of the next chapter, or `nil` if there is
+  #   no next chapter.
+  def next_number
+    if number == book.chapters_count
+      nil
+    else
+      number + 1
+    end
+  end
+
   # Returns the title of the chapter in the format "Chapter <number>".
   #
   # @return [String] the formatted chapter title

--- a/app/models/bible/verse.rb
+++ b/app/models/bible/verse.rb
@@ -53,6 +53,19 @@ class Bible::Verse < ApplicationRecord
   validates :number, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :translation, presence: true
 
+  # Returns the number of the next verse in the chapter, or `nil` if the current
+  # verse is the last one in the chapter.
+  #
+  # @return [Integer, nil] The number of the next verse, or `nil` if there is no
+  #   next verse.
+  def next_number
+    if number == chapter.verses_count
+      nil
+    else
+      number + 1
+    end
+  end
+
   # Formats an array of verse numbers into a compact string representation.
   #
   # Consecutive numbers are grouped into ranges (e.g., "1-10"), while

--- a/app/models/bible/verse.rb
+++ b/app/models/bible/verse.rb
@@ -66,6 +66,19 @@ class Bible::Verse < ApplicationRecord
     end
   end
 
+  # Returns the number of the previous verse in the chapter, or `nil` if the
+  # current verse is the first one in the chapter.
+  #
+  # @return [Integer, nil] The number of the previous verse, or `nil` if there
+  #   is no previous verse.
+  def previous_number
+    if number == 1
+      nil
+    else
+      number - 1
+    end
+  end
+
   # Formats an array of verse numbers into a compact string representation.
   #
   # Consecutive numbers are grouped into ranges (e.g., "1-10"), while

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -196,7 +196,7 @@
   <% if @footnotes.any? %>
   <div class="relative">
     <div class="absolute inset-0 flex items-center" aria-hidden="true">
-      <div class="w-full border-t border-gray-300"></div>
+      <div class="w-full border-t border-gray-200"></div>
     </div>
 
     <div class="relative flex justify-center">
@@ -226,6 +226,78 @@
     </ul>
   </section>
   <% end %>
+
+  <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+    <% if @chapter.previous_number %>
+      <div class="-mt-px flex w-0 flex-1">
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+          <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
+          </svg>
+          <%= "Previous Chapter" %>
+        <% end %>
+      </div>
+    <% elsif @book.previous_number %>
+      <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
+      <div class="-mt-px flex w-0 flex-1">
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+          <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
+          </svg>
+          <%= "Previous Book" %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1"></div>
+    <% end %>
+
+    <div class="hidden md:-mt-px md:flex">
+      <% pagination_window = 3 %>
+
+      <% pagination_lower_bound = @chapter.number - pagination_window %>
+      <% pagination_lower_bound = 1 if pagination_lower_bound.negative? || pagination_lower_bound.zero? %>
+
+      <% pagination_upper_bound = @chapter.number + pagination_window %>
+      <% pagination_upper_bound = @book.chapters_count if pagination_upper_bound > @book.chapters_count %>
+
+      <% pagination_lower_bound = pagination_upper_bound - (pagination_window * 2) if pagination_upper_bound > 6 && pagination_lower_bound > 1 %>
+      <% pagination_upper_bound = pagination_lower_bound + (pagination_window * 2) if pagination_lower_bound < 6 && pagination_upper_bound < @book.chapters_count %>
+
+      <% pagination_pages = [pagination_lower_bound, pagination_upper_bound].compact.uniq %>
+      <% pagination_pages = (pagination_pages.min..pagination_pages.max).to_a %>
+
+      <% for pagination_page in pagination_pages %>
+        <% if pagination_page == @chapter.number %>
+          <%= link_to @chapter.number, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-indigo-500 px-4 pt-6 text-sm font-medium text-indigo-600" %>
+        <% else %>
+          <%= link_to pagination_page, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% if @chapter.next_number %>
+      <div class="-mt-px flex w-0 flex-1 justify-end">
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+          <%= "Next Chapter" %>
+          <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
+      </div>
+    <% elsif @book.next_number %>
+      <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
+      <div class="-mt-px flex w-0 flex-1 justify-end">
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+          <%= "Next Book" %>
+          <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1 justify-end"></div>
+    <% end %>
+  </nav>
 
   <hr class="my-6 border-gray-300">
 

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -97,7 +97,7 @@
   <% if @footnotes.any? %>
   <div class="relative">
     <div class="absolute inset-0 flex items-center" aria-hidden="true">
-      <div class="w-full border-t border-gray-300"></div>
+      <div class="w-full border-t border-gray-200"></div>
     </div>
 
     <div class="relative flex justify-center">
@@ -127,6 +127,78 @@
     </ul>
   </section>
   <% end %>
+
+  <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+    <% if @chapter.previous_number %>
+      <div class="-mt-px flex w-0 flex-1">
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+          <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
+          </svg>
+          <%= "Previous Chapter" %>
+        <% end %>
+      </div>
+    <% elsif @book.previous_number %>
+      <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
+      <div class="-mt-px flex w-0 flex-1">
+        <%= link_to commentary_book_chapter_path(book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+          <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
+          </svg>
+          <%= "Previous Book" %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1"></div>
+    <% end %>
+
+    <div class="hidden md:-mt-px md:flex">
+      <% pagination_window = 3 %>
+
+      <% pagination_lower_bound = @chapter.number - pagination_window %>
+      <% pagination_lower_bound = 1 if pagination_lower_bound.negative? || pagination_lower_bound.zero? %>
+
+      <% pagination_upper_bound = @chapter.number + pagination_window %>
+      <% pagination_upper_bound = @book.chapters_count if pagination_upper_bound > @book.chapters_count %>
+
+      <% pagination_lower_bound = pagination_upper_bound - (pagination_window * 2) if pagination_upper_bound > 6 && pagination_lower_bound > 1 %>
+      <% pagination_upper_bound = pagination_lower_bound + (pagination_window * 2) if pagination_lower_bound < 6 && pagination_upper_bound < @book.chapters_count %>
+
+      <% pagination_pages = [pagination_lower_bound, pagination_upper_bound].compact.uniq %>
+      <% pagination_pages = (pagination_pages.min..pagination_pages.max).to_a %>
+
+      <% for pagination_page in pagination_pages %>
+        <% if pagination_page == @chapter.number %>
+          <%= link_to @chapter.number, commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-indigo-500 px-4 pt-6 text-sm font-medium text-indigo-600" %>
+        <% else %>
+          <%= link_to pagination_page, commentary_book_chapter_path(book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% if @chapter.next_number %>
+      <div class="-mt-px flex w-0 flex-1 justify-end">
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+          <%= "Next Chapter" %>
+          <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
+      </div>
+    <% elsif @book.next_number %>
+      <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
+      <div class="-mt-px flex w-0 flex-1 justify-end">
+        <%= link_to commentary_book_chapter_path(book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+          <%= "Next Book" %>
+          <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1 justify-end"></div>
+    <% end %>
+  </nav>
 
   <hr class="my-6 border-gray-300">
 

--- a/spec/models/bible/book_spec.rb
+++ b/spec/models/bible/book_spec.rb
@@ -22,4 +22,24 @@ RSpec.describe Bible::Book, type: :model do
       end
     end
   end
+
+  describe '#previous_number' do
+    context 'when the book is the first book in the translation' do
+      it 'returns nil' do
+        book = FactoryBot.create(:translation_book, translation: translation, number: 1)
+        FactoryBot.create(:translation_book, translation: translation, number: 2)
+
+        expect(book.previous_number).to be_nil
+      end
+    end
+
+    context 'when the book is not the first book in the translation' do
+      it 'returns the previous book number' do
+        FactoryBot.create(:translation_book, translation: translation, number: 1)
+        book = FactoryBot.create(:translation_book, translation: translation, number: 2)
+
+        expect(book.previous_number).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/bible/book_spec.rb
+++ b/spec/models/bible/book_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Bible::Book, type: :model do
+  let(:translation) { FactoryBot.create(:translation_bsb) }
+
+  describe '#next_number' do
+    context 'when the book is the last book in the translation' do
+      it 'returns nil' do
+        FactoryBot.create(:translation_book, translation: translation, number: 1)
+        book = FactoryBot.create(:translation_book, translation: translation, number: 2)
+
+        expect(book.next_number).to be_nil
+      end
+    end
+
+    context 'when the book is not the last book in the translation' do
+      it 'returns the next book number' do
+        book = FactoryBot.create(:translation_book, translation: translation, number: 1)
+        FactoryBot.create(:translation_book, translation: translation, number: 2)
+
+        expect(book.next_number).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/models/bible/chapter_spec.rb
+++ b/spec/models/bible/chapter_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Bible::Chapter, type: :model do
     end
   end
 
+  describe '#next_number' do
+    context 'when the chapter is the last chapter in the book' do
+      it 'returns nil' do
+        FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
+        chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 2)
+
+        expect(chapter.next_number).to be_nil
+      end
+    end
+
+    context 'when the chapter is not the last chapter in the book' do
+      it 'returns the next chapter number' do
+        chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
+        FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 2)
+
+        expect(chapter.next_number).to eq(2)
+      end
+    end
+  end
+
   describe '#title' do
     it 'returns the chapter title' do
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)

--- a/spec/models/bible/chapter_spec.rb
+++ b/spec/models/bible/chapter_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe Bible::Chapter, type: :model do
     end
   end
 
+  describe '#previous_number' do
+    context 'when the chapter is the first chapter in the book' do
+      it 'returns nil' do
+        chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
+        FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 2)
+
+        expect(chapter.previous_number).to be_nil
+      end
+    end
+
+    context 'when the chapter is not the first chapter in the book' do
+      it 'returns the previous chapter number' do
+        FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
+        chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 2)
+
+        expect(chapter.previous_number).to eq(1)
+      end
+    end
+  end
+
   describe '#title' do
     it 'returns the chapter title' do
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)

--- a/spec/models/bible/verses_spec.rb
+++ b/spec/models/bible/verses_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Bible::Verse, type: :model do
+  let(:translation) { FactoryBot.create(:translation_bsb) }
+  let(:book) { FactoryBot.create(:translation_book, translation: translation, title: "Genesis") }
+  let(:chapter) { FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1) }
+
+  describe '#next_number' do
+    context 'when the verse is the last verse in the chapter' do
+      it 'returns nil' do
+        FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+
+        expect(verse.next_number).to be_nil
+      end
+    end
+
+    context 'when the verse is not the last verse in the chapter' do
+      it 'returns the next verse number' do
+        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+
+        expect(verse.next_number).to eq(2)
+      end
+    end
+  end
+
   describe '.format_verse_numbers' do
     it 'returns correctly formatted verse numbers' do
       aggregate_failures do

--- a/spec/models/bible/verses_spec.rb
+++ b/spec/models/bible/verses_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe Bible::Verse, type: :model do
     end
   end
 
+  describe '#previous_number' do
+    context 'when the verse is the first verse in the chapter' do
+      it 'returns nil' do
+        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+
+        expect(verse.previous_number).to be_nil
+      end
+    end
+
+    context 'when the verse is not the first verse in the chapter' do
+      it 'returns the previous verse number' do
+        FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+
+        expect(verse.previous_number).to eq(1)
+      end
+    end
+  end
+
   describe '.format_verse_numbers' do
     it 'returns correctly formatted verse numbers' do
       aggregate_failures do

--- a/spec/requests/chapters_controller_spec.rb
+++ b/spec/requests/chapters_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ChaptersController, type: :request do
   describe 'GET #show' do
     it 'returns the correct response' do
       translation = FactoryBot.create(:translation)
-      book = FactoryBot.create(:translation_book, translation: translation)
+      book = FactoryBot.create(:translation_book, translation: translation, number: 1)
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
 
       get translation_book_chapter_path translation_code: translation.code.downcase, book_slug: book.slug, number: chapter.number

--- a/spec/requests/commentary/chapters_controller_spec.rb
+++ b/spec/requests/commentary/chapters_controller_spec.rb
@@ -19,7 +19,7 @@ module Commentary
     describe 'GET #show' do
       it 'returns the correct response' do
         translation = FactoryBot.create(:translation_bsb)
-        book = FactoryBot.create(:translation_book, translation: translation)
+        book = FactoryBot.create(:translation_book, translation: translation, number: 1)
         chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
 
         get commentary_book_chapter_path book_slug: book.slug, number: chapter.number


### PR DESCRIPTION
This pull request introduces navigation enhancements and pagination for Bible books, chapters, and verses, alongside corresponding tests to ensure functionality. It also updates the UI for consistency and usability.

### Changes

#### Navigation Enhancements

* Added `next_number` and `previous_number` methods to `Bible::Book`, `Bible::Chapter`, and `Bible::Verse` models to determine the next and previous elements within their respective contexts.
* Updated `app/views/chapters/show.html.erb` and `app/views/commentary/chapters/show.html.erb` to include navigation links for moving between books and chapters, as well as pagination for chapters.

#### UI Improvements

* Changed border color for visual consistency in `app/views/chapters/show.html.erb` and `app/views/commentary/chapters/show.html.erb`.

#### Test Coverage

* Added RSpec tests for `next_number` and `previous_number` methods in `Bible::Book`, `Bible::Chapter`, and `Bible::Verse` models to validate navigation logic.