### PR TITLE
Update and improve section controller and views logic

### DIFF
--- a/app/controllers/commentary/sections_controller.rb
+++ b/app/controllers/commentary/sections_controller.rb
@@ -11,6 +11,9 @@ module Commentary
       @section = Bible::Section.find_by!(translation: @translation, book: @book, chapter: @chapter, verse_spec: section_verse_spec)
       @verses = @section.segments.map { |segment| segment.verses }.compact.uniq
 
+      @previous_section = Bible::Section.expositable.where(translation: @translation, book: @book).where("id < ?", @section.id).order(id: :desc).first
+      @next_section = Bible::Section.expositable.where(translation: @translation, book: @book).where("id > ?", @section.id).order(id: :asc).first
+
       @footnotes_mapping = {}
       @footnotes = Bible::Footnote.where(translation: @translation, book: @book, chapter: @chapter, verse: @verses).order(created_at: :asc)
       @footnotes.each.with_index(1) do |footnote, footnote_number|

--- a/app/controllers/commentary/sections_controller.rb
+++ b/app/controllers/commentary/sections_controller.rb
@@ -9,6 +9,7 @@ module Commentary
       @book = Bible::Book.find_by! translation: @translation, slug: book_slug
       @chapter = Bible::Chapter.find_by! translation: @translation, book: @book, number: chapter_number
       @section = Bible::Section.find_by!(translation: @translation, book: @book, chapter: @chapter, verse_spec: section_verse_spec)
+      @exposition_content = Exposition::Content.find_by!(section: @section)
       @verses = @section.segments.map { |segment| segment.verses }.compact.uniq
 
       @previous_section = Bible::Section.expositable.where(translation: @translation, book: @book).where("id < ?", @section.id).order(id: :desc).first

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,4 +7,12 @@ module MarkdownHelper
     html = Kramdown::Document.new(text).to_html
     sanitize(html, tags: %w[strong em p])
   end
+
+  # Strips all Markdown formatting from the given text.
+  #
+  # @param text [String] The Markdown text to be stripped.
+  # @return [String] The plain text with all Markdown removed.
+  def strip_markdown(text)
+    Nokogiri::HTML(markdown_to_html(text)).text.strip
+  end
 end

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -230,7 +230,7 @@
   <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
     <% if @chapter.previous_number %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -240,7 +240,7 @@
     <% elsif @book.previous_number %>
       <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>  
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -268,16 +268,16 @@
 
       <% for pagination_page in pagination_pages %>
         <% if pagination_page == @chapter.number %>
-          <%= link_to @chapter.number, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-500 px-4 pt-6 text-sm font-medium text-blue-600" %>
+          <%= link_to @chapter.number, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-600 px-4 pt-6 text-sm font-medium text-blue-600" %>
         <% else %>
-          <%= link_to pagination_page, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" %>
+          <%= link_to pagination_page, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" %>
         <% end %>
       <% end %>
     </div>
 
     <% if @chapter.next_number %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>  
           <%= "Next Chapter" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
@@ -287,7 +287,7 @@
     <% elsif @book.next_number %>
       <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>
           <%= "Next Book" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -56,7 +56,7 @@
     <% @sections.each do |section| %>
       <%= tag.div id: "section-#{section.id}" do %>
         <% if section.expositable? %>
-          <div class="overflow-hidden rounded-lg bg-gray-100 font-medium">
+          <div class="overflow-hidden rounded-lg bg-blue-50 font-medium">
             <div class="px-4 py-5 sm:p-6">
               <%= render partial: "section", locals: { section: section }  %>
             </div>

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -131,7 +131,7 @@
   <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
     <% if @chapter.previous_number %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -141,7 +141,7 @@
     <% elsif @book.previous_number %>
       <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to commentary_book_chapter_path(book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
+        <%= link_to commentary_book_chapter_path(book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>  
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -169,16 +169,16 @@
 
       <% for pagination_page in pagination_pages %>
         <% if pagination_page == @chapter.number %>
-          <%= link_to @chapter.number, commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-500 px-4 pt-6 text-sm font-medium text-blue-600" %>
+          <%= link_to @chapter.number, commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-600 px-4 pt-6 text-sm font-medium text-blue-600" %>
         <% else %>
-          <%= link_to pagination_page, commentary_book_chapter_path(book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" %>
+          <%= link_to pagination_page, commentary_book_chapter_path(book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" %>
         <% end %>
       <% end %>
     </div>
 
     <% if @chapter.next_number %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>  
           <%= "Next Chapter" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
@@ -188,7 +188,7 @@
     <% elsif @book.next_number %>
       <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to commentary_book_chapter_path(book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
+        <%= link_to commentary_book_chapter_path(book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>
           <%= "Next Book" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -73,7 +73,7 @@
                   <div class="w-full border-t border-gray-300"></div>
                 </div>
                 <div class="relative flex justify-center">
-                  <%= link_to commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, verse_spec: section.verse_spec), class: "inline-flex items-center gap-x-1.5 rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50" do %>
+                  <%= link_to commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, verse_spec: section.verse_spec), class: "inline-flex items-center gap-x-1.5 rounded-l-md rounded-r-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50" do %>
                     <svg class="-mr-0.5 -ml-1 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
                       <path d="M10.75 4.75a.75.75 0 0 0-1.5 0v4.5h-4.5a.75.75 0 0 0 0 1.5h4.5v4.5a.75.75 0 0 0 1.5 0v-4.5h4.5a.75.75 0 0 0 0-1.5h-4.5v-4.5Z" />
                     </svg>

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -70,7 +70,7 @@
 
               <div class="mt-6 relative">
                 <div class="absolute inset-0 flex items-center" aria-hidden="true">
-                  <div class="w-full border-t border-gray-300"></div>
+                  <div class="w-[40%] mx-auto border-t border-gray-300"></div>
                 </div>
                 <div class="relative flex justify-center">
                   <%= link_to commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, verse_spec: section.verse_spec), class: "inline-flex items-center gap-x-1.5 rounded-l-md rounded-r-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50" do %>

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -161,7 +161,7 @@
     <div>
       <ul class="pl-5 list-disc">
         <% @section.exposition_content.alternative_interpretations.each do |alternative_interpretation| %>
-          <li><%= alternative_interpretation %></li>
+          <li><b><%= alternative_interpretation.title %>:</b> <%= alternative_interpretation.note %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :description do %>
-  <%= "Get detailed context and meaning for #{@chapter.full_title} S##{@section.id} — presented clearly and concisely." %>
+  <%= truncate(strip_markdown(@section.exposition_content.summary), length: 200, separator: ' ') %>
 <% end %>
 
 <nav class="mb-8 flex">

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :description do %>
-  <%= truncate(strip_markdown(@section.exposition_content.summary), length: 200, separator: ' ') %>
+  <%= truncate(strip_markdown(@exposition_content.summary), length: 200, separator: ' ') %>
 <% end %>
 
 <nav class="mb-8 flex">
@@ -94,7 +94,7 @@
     </div>
 
     <div class="mt-8 mb-4 prose max-w-none">
-      <%= markdown_to_html @section.exposition_content.summary %>
+      <%= markdown_to_html @exposition_content.summary %>
     </div>
   </div>
 
@@ -102,13 +102,13 @@
   <div>
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Context</h3>
     <div>
-      <%= @section.exposition_content.context %>
+      <%= @exposition_content.context %>
     </div>
 
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Verse-by-Verse</h3>
     <div>
       <div class="space-y-6">
-        <% @section.exposition_content.analyses.order(position: :asc).each do |analysis| %>
+        <% @exposition_content.analyses.order(position: :asc).each do |analysis| %>
           <div>
             <blockquote class="relative pl-8 border-l-4 border-blue-300">
               <span class="absolute left-2 top-0 text-5xl leading-none text-blue-300 select-none">“</span>
@@ -123,7 +123,7 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Cross References</h3>
     <div>
       <ul class="pl-5 list-disc space-y-2">
-        <% @section.exposition_content.cross_references.each do |cross_reference| %>
+        <% @exposition_content.cross_references.each do |cross_reference| %>
           <li><b><%= cross_reference.reference %>:</b> <%= cross_reference.note %></li>
         <% end %>
       </ul>
@@ -132,7 +132,7 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Highlights</h3>
     <div>
       <ul class="pl-5 list-disc space-y-1">
-        <% @section.exposition_content.highlights.each do |highlight| %>
+        <% @exposition_content.highlights.each do |highlight| %>
           <li><%= highlight %></li>
         <% end %>
       </ul>
@@ -141,7 +141,7 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Insights (Christ-Centred)</h3>
     <div>
       <ul class="pl-5 list-disc space-y-1">
-        <% @section.exposition_content.insights.each do |insight| %>
+        <% @exposition_content.insights.each do |insight| %>
           <li><%= insight.note %></li>
         <% end %>
       </ul>
@@ -150,17 +150,17 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Key Themes</h3>
     <div>
       <ul class="pl-5 list-disc space-y-2">
-        <% @section.exposition_content.key_themes.each do |key_theme| %>
+        <% @exposition_content.key_themes.each do |key_theme| %>
           <li><b><%= key_theme.theme %>:</b> <%= key_theme.description %></li>
         <% end %>
       </ul>
     </div>
 
-    <% if @section.exposition_content.alternative_interpretations.any? %>
+    <% if @exposition_content.alternative_interpretations.any? %>
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Alternative Interpretations</h3>
     <div>
       <ul class="pl-5 list-disc">
-        <% @section.exposition_content.alternative_interpretations.each do |alternative_interpretation| %>
+        <% @exposition_content.alternative_interpretations.each do |alternative_interpretation| %>
           <li><b><%= alternative_interpretation.title %>:</b> <%= alternative_interpretation.note %></li>
         <% end %>
       </ul>
@@ -173,7 +173,7 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Personal Applications</h3>
     <div>
       <ul class="pl-5 list-disc space-y-2">
-        <% @section.exposition_content.personal_applications.each do |personal_application| %>
+        <% @exposition_content.personal_applications.each do |personal_application| %>
           <li><b><%= personal_application.title %>:</b> <%= personal_application.note %></li>
         <% end %>
       </ul>
@@ -182,7 +182,7 @@
     <h3 class="mt-8 mb-4 text-xl font-semibold text-pretty text-gray-900">Reflections</h3>
     <div>
       <ul class="pl-5 list-disc space-y-1">
-        <% @section.exposition_content.reflections.each do |reflection| %>
+        <% @exposition_content.reflections.each do |reflection| %>
           <li><%= reflection %></li>
         <% end %>
       </ul>

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= "Study #{@chapter.full_title} S##{@section.id} | #{@translation.code} | #{Settings.app.name.external}" %>
+  <%= "Study #{@section.title} | #{@translation.code} | #{Settings.app.name.external}" %>
 <% end %>
 
 <% content_for :description do %>

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -52,7 +52,7 @@
 
   <h2 class="mt-8 mb-4 text-3xl font-semibold text-pretty text-gray-900">Passage</h2>
   <div>
-    <div class="mt-8 mb-4 overflow-hidden rounded-lg bg-gray-100 font-medium">
+    <div class="mt-8 mb-4 overflow-hidden rounded-lg bg-blue-50 font-medium">
       <div class="px-4 py-5 sm:p-6">
         <%= render partial: "section", locals: { section: @section }  %>
 
@@ -63,7 +63,7 @@
               <div class="w-full border-t border-gray-300"></div>
             </div>
             <div class="relative flex justify-start">
-              <span class="bg-gray-100 pr-2 text-sm text-gray-500">Footnotes</span>
+              <span class="bg-blue-50 pr-2 text-sm text-gray-500">Footnotes</span>
             </div>
           </div>
 

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -189,7 +189,39 @@
     </div>
   </div>
 
-  <hr class="mt-12 mb-6 border-gray-300">
+  <nav class="mt-18 mb-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+    <% if @previous_section && @previous_section.exposition_content %>
+      <div class="-mt-px flex w-0 flex-1">
+        <%= link_to commentary_book_chapter_section_path(book_slug: @previous_section.book.slug, chapter_number: @previous_section.chapter.number, verse_spec: @previous_section.verse_spec), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>
+          <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
+          </svg>
+          <%= @previous_section.title %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1"></div>
+    <% end %>
+
+    <div class="hidden md:-mt-px md:flex">
+      <%= link_to "Back to #{@chapter.full_title} Study", commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" %>
+    </div>
+
+    <% if @next_section && @next_section.exposition_content %>
+      <div class="-mt-px flex w-0 flex-1 justify-end">
+        <%= link_to commentary_book_chapter_section_path(book_slug: @next_section.book.slug, chapter_number: @next_section.chapter.number, verse_spec: @next_section.verse_spec), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-600 hover:border-blue-400 hover:text-blue-800" do %>  
+          <%= @next_section.title %>
+          <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="-mt-px flex w-0 flex-1 justify-end"></div>
+    <% end %>
+  </nav>
+
+  <hr class="my-6 border-gray-300">
 
   <section class="my-6" id="copyright">
     <p class="text-center text-xs/6 text-gray-600">

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -110,8 +110,8 @@
       <div class="space-y-6">
         <% @section.exposition_content.analyses.order(position: :asc).each do |analysis| %>
           <div>
-            <blockquote class="relative pl-8 border-l-4 border-gray-300">
-              <span class="absolute left-2 top-0 text-5xl leading-none text-gray-300 select-none">“</span>
+            <blockquote class="relative pl-8 border-l-4 border-blue-300">
+              <span class="absolute left-2 top-0 text-5xl leading-none text-blue-300 select-none">“</span>
               <p class="text-base/7 italic font-medium leading-relaxed text-gray-700"><%= analysis.part %></p>
             </blockquote>
             <div class="mt-2 text-base/7 text-gray-600"><%= analysis.note %></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || Settings.app.name.external %></title>
+    <%= tag.title(content_for(:title) || Settings.app.name.external) %>
     <%= tag.meta name: "description", content: content_for(:description) %>
     <%= tag.meta name: "viewport", content: "width=device-width,initial-scale=1" %>
     <%= tag.meta name: "apple-mobile-web-app-title", content: "Thy Word" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,11 @@
 <html>
   <head>
     <title><%= content_for(:title) || Settings.app.name.external %></title>
-    <meta name="description" content="<%= h(content_for(:description)) %>">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-title" content="Thy Word" />
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
+    <%= tag.meta name: "description", content: content_for(:description) %>
+    <%= tag.meta name: "viewport", content: "width=device-width,initial-scale=1" %>
+    <%= tag.meta name: "apple-mobile-web-app-title", content: "Thy Word" %>
+    <%= tag.meta name: "apple-mobile-web-app-capable", content: "yes" %>
+    <%= tag.meta name: "mobile-web-app-capable", content: "yes" %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -46,4 +46,38 @@ RSpec.describe MarkdownHelper, type: :helper do
       end
     end
   end
+
+  describe "#strip_markdown" do
+    it "removes Markdown formatting and returns plain text" do
+      markdown_text = "# Hello *World*"
+      expected_text = "Hello World"
+      result = helper.strip_markdown(markdown_text)
+
+      expect(result).to eq(expected_text)
+    end
+
+    it "handles empty text" do
+      markdown_text = ""
+      expected_text = ""
+      result = helper.strip_markdown(markdown_text)
+
+      expect(result).to eq(expected_text)
+    end
+
+    it "removes HTML tags and returns plain text" do
+      markdown_text = "<strong>Bold</strong> and <em>Italic</em>"
+      expected_text = "Bold and Italic"
+      result = helper.strip_markdown(markdown_text)
+
+      expect(result).to eq(expected_text)
+    end
+
+    it "handles complex Markdown and returns plain text" do
+      markdown_text = "# Title\n\nThis is a **bold** statement with *italic* text."
+      expected_text = "Title\n\nThis is a bold statement with italic text."
+      result = helper.strip_markdown(markdown_text)
+
+      expect(result).to eq(expected_text)
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces several updates to enhance the functionality and styling of the application, focusing on exposition content handling, navigation improvements, and visual design updates. The most significant changes include adding support for exposition content in section views, improving navigation between sections and chapters, and updating the color scheme for better visual consistency.

### Changes

#### Functional Enhancements

* Added `@exposition_content` to the `show` action in `SectionsController` to fetch exposition content associated with a section. This enables rendering exposition-related data in views.
* Introduced helper method `strip_markdown` in `MarkdownHelper` to remove Markdown formatting from text, making it suitable for plain-text contexts.

#### Navigation Improvements

* Implemented `@previous_section` and `@next_section` in `SectionsController` to enable navigation between adjacent sections.
* Adjusted chapter navigation links in `chapters/show.html.erb` and `commentary/chapters/show.html.erb` to use a darker blue color (`text-blue-600`) and updated hover styles for improved accessibility.

#### Visual Design Updates

* Updated background colors for section containers in `commentary/chapters/show.html.erb` and `commentary/sections/show.html.erb` to use `bg-blue-50` for a more cohesive design.
* Changed border and text colors in various components to align with the updated blue color scheme.

#### Exposition Content Integration

* Replaced `@section.exposition_content` references with `@exposition_content` in `commentary/sections/show.html.erb` for consistency and to leverage the newly added `@exposition_content` instance variable.
* Updated the page title and meta description in `commentary/sections/show.html.erb` to dynamically use the section's title and a truncated summary of its exposition content.