### PR TITLE
Use consistent colour scheme on links

### DIFF
--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -230,7 +230,7 @@
   <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
     <% if @chapter.previous_number %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -240,7 +240,7 @@
     <% elsif @book.previous_number %>
       <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -268,16 +268,16 @@
 
       <% for pagination_page in pagination_pages %>
         <% if pagination_page == @chapter.number %>
-          <%= link_to @chapter.number, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-indigo-500 px-4 pt-6 text-sm font-medium text-indigo-600" %>
+          <%= link_to @chapter.number, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-500 px-4 pt-6 text-sm font-medium text-blue-600" %>
         <% else %>
-          <%= link_to pagination_page, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" %>
+          <%= link_to pagination_page, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" %>
         <% end %>
       <% end %>
     </div>
 
     <% if @chapter.next_number %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
           <%= "Next Chapter" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
@@ -287,7 +287,7 @@
     <% elsif @book.next_number %>
       <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
           <%= "Next Book" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -131,7 +131,7 @@
   <nav class="my-6 flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
     <% if @chapter.previous_number %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.previous_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -141,7 +141,7 @@
     <% elsif @book.previous_number %>
       <% previous_book = Bible::Book.find_by!(translation: @translation, number: @book.previous_number) %>
       <div class="-mt-px flex w-0 flex-1">
-        <%= link_to commentary_book_chapter_path(book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+        <%= link_to commentary_book_chapter_path(book_slug: previous_book.slug, number: previous_book.chapters_count), class: "inline-flex items-center border-t-2 border-transparent pt-6 pr-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
           <svg class="mr-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a.75.75 0 0 1-.75.75H4.66l2.1 1.95a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 1 1 1.02 1.1l-2.1 1.95h12.59A.75.75 0 0 1 18 10Z" clip-rule="evenodd" />
           </svg>
@@ -169,16 +169,16 @@
 
       <% for pagination_page in pagination_pages %>
         <% if pagination_page == @chapter.number %>
-          <%= link_to @chapter.number, commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-indigo-500 px-4 pt-6 text-sm font-medium text-indigo-600" %>
+          <%= link_to @chapter.number, commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.number), class: "inline-flex items-center border-t-2 border-blue-500 px-4 pt-6 text-sm font-medium text-blue-600" %>
         <% else %>
-          <%= link_to pagination_page, commentary_book_chapter_path(book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" %>
+          <%= link_to pagination_page, commentary_book_chapter_path(book_slug: @book.slug, number: pagination_page), class: "inline-flex items-center border-t-2 border-transparent px-4 pt-6 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" %>
         <% end %>
       <% end %>
     </div>
 
     <% if @chapter.next_number %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>  
+        <%= link_to commentary_book_chapter_path(book_slug: @book.slug, number: @chapter.next_number), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>  
           <%= "Next Chapter" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />
@@ -188,7 +188,7 @@
     <% elsif @book.next_number %>
       <% next_book = Bible::Book.find_by!(translation: @translation, number: @book.next_number) %>
       <div class="-mt-px flex w-0 flex-1 justify-end">
-        <%= link_to commentary_book_chapter_path(book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to commentary_book_chapter_path(book_slug: next_book.slug, number: 1), class: "inline-flex items-center border-t-2 border-transparent pt-6 pl-1 text-sm font-medium text-blue-500 hover:border-blue-300 hover:text-blue-700" do %>
           <%= "Next Book" %>
           <svg class="ml-3 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M2 10a.75.75 0 0 1 .75-.75h12.59l-2.1-1.95a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.1-1.95H2.75A.75.75 0 0 1 2 10Z" clip-rule="evenodd" />

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -42,7 +42,7 @@
             <%= "Read the #{@translation.code} Bible" %>
           <% end %>
 
-          <%= link_to commentary_books_path, class: "w-full sm:w-auto rounded-md bg-blue-50 px-3.5 py-2.5 text-sm font-semibold text-blue-500 shadow-xs hover:bg-indigo-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-50" do %>  
+          <%= link_to commentary_books_path, class: "w-full sm:w-auto rounded-md bg-blue-50 px-3.5 py-2.5 text-sm font-semibold text-blue-500 shadow-xs hover:bg-blue-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-50" do %>  
             Study with Commentary
           <% end %>
         </div>


### PR DESCRIPTION
This pull request updates the color scheme of navigation and pagination links across multiple views to enhance consistency and improve the user interface. The changes primarily involve replacing gray and indigo color classes with blue color classes in the `app/views/chapters/show.html.erb`, `app/views/commentary/chapters/show.html.erb`, and `app/views/pages/home.html.erb` files.

### Changes

#### Navigation And Pagination Styling Updates

* **Chapter navigation links**: Updated the text and hover colors of "Previous Chapter," "Next Chapter," and "Next Book" links to use blue (`text-blue-500`, `hover:text-blue-700`) instead of gray (`text-gray-500`, `hover:text-gray-700`) in `app/views/chapters/show.html.erb`. 
* **Pagination links**: Changed the active and inactive pagination link colors to use blue (`border-blue-500`, `text-blue-600`, `hover:text-blue-700`) instead of indigo and gray in `app/views/chapters/show.html.erb`.
* **Commentary chapter navigation links**: Applied the same blue color updates to "Previous Chapter," "Next Chapter," and "Next Book" links in `app/views/commentary/chapters/show.html.erb`. 
* **Commentary pagination links**: Updated the active and inactive pagination link colors to match the blue color scheme in `app/views/commentary/chapters/show.html.erb`.

#### Home Page Button Styling

* **"Study with Commentary" button**: Adjusted the hover and focus-visible background colors to blue (`hover:bg-blue-100`, `focus-visible:outline-blue-50`) for consistency in `app/views/pages/home.html.erb`.