### PR TITLE
Load sections using it's verse-spec

### DIFF
--- a/app/controllers/commentary/sections_controller.rb
+++ b/app/controllers/commentary/sections_controller.rb
@@ -3,12 +3,12 @@ module Commentary
     def show
       book_slug = params[:book_slug].to_s.strip
       chapter_number = params[:chapter_number].to_s.strip
-      section_id = params[:id].to_s.strip
+      section_verse_spec = params[:verse_spec].to_s.strip
 
       @translation = Bible::Translation.find_by! code: Settings.bible.defaults.translation
       @book = Bible::Book.find_by! translation: @translation, slug: book_slug
       @chapter = Bible::Chapter.find_by! translation: @translation, book: @book, number: chapter_number
-      @section = Bible::Section.find_by!(translation: @translation, book: @book, chapter: @chapter, id: section_id)
+      @section = Bible::Section.find_by!(translation: @translation, book: @book, chapter: @chapter, verse_spec: section_verse_spec)
       @verses = @section.segments.map { |segment| segment.verses }.compact.uniq
 
       @footnotes_mapping = {}

--- a/app/jobs/set_bible_section_verse_spec_job.rb
+++ b/app/jobs/set_bible_section_verse_spec_job.rb
@@ -1,0 +1,31 @@
+class SetBibleSectionVerseSpecJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Rails.logger.info "[SetBibleSectionVerseSpecJob] Starting setting of Bible section verse-specs..."
+
+    Bible::Translation.find_each do |translation|
+      Rails.logger.info "[SetBibleSectionVerseSpecJob] Set section verse-spec for Translation: #{translation.name} (#{translation.code})"
+
+      translation.books.find_each do |book|
+        Rails.logger.info "[SetBibleSectionVerseSpecJob] Set section verse-spec for Book: #{book.title} (#{book.code})"
+
+        book.chapters.find_each do |chapter|
+          Rails.logger.info "[SetBibleSectionVerseSpecJob] Set section verse-spec for Chapter: #{book.title} #{chapter.number}"
+
+            sections = Bible::Section.where(translation: translation, book: book, chapter: chapter).order(position: :asc)
+            sections.each do |section|
+              verse_spec = section.generate_verse_spec
+
+              next unless verse_spec
+
+              section.update! verse_spec: verse_spec
+              Rails.logger.info "[SetBibleSectionVerseSpecJob] Set section verse-spec for Section: #{section.id} (with verse_spec #{verse_spec})"
+            end
+        end
+      end
+    end
+
+    Rails.logger.info "[SetBibleSectionVerseSpecJob] Finished setting of Bible section verse-specs."
+  end
+end

--- a/app/models/bible/section.rb
+++ b/app/models/bible/section.rb
@@ -8,6 +8,7 @@
 # --------------------- | ------------------ | ---------------------------
 # **`id`**              | `bigint`           | `not null, primary key`
 # **`position`**        | `integer`          | `not null`
+# **`verse_spec`**      | `string`           |
 # **`created_at`**      | `datetime`         | `not null`
 # **`updated_at`**      | `datetime`         | `not null`
 # **`book_id`**         | `bigint`           | `not null`

--- a/app/models/bible/section.rb
+++ b/app/models/bible/section.rb
@@ -56,6 +56,9 @@ class Bible::Section < ApplicationRecord
   validates :position, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :translation, presence: true
 
+  # Scopes
+  scope :expositable, -> { where.not(verse_spec: nil) }
+
   # Determines if a section is ready for exposition.
   #
   # @return [Boolean] true if any segment's USX style is a content style, false

--- a/app/models/bible/section.rb
+++ b/app/models/bible/section.rb
@@ -64,6 +64,26 @@ class Bible::Section < ApplicationRecord
     segments.where(usx_style: Bible::Segment::CONTENT_STYLES.map(&:to_s)).exists?
   end
 
+  # Generate the verse spec for the section based on the segments and their
+  # associated verses.
+  #
+  # A verse spec is a formatted string representation of verse numbers for the
+  # section. This method checks if any of the associated segments contain
+  # verses. If so, it collects all the verse numbers, orders them, removes
+  # duplicates, and formats them into a human-readable string.
+
+  # @return [String, nil] A formatted string of verse numbers if verses exist, or nil otherwise.
+  def generate_verse_spec
+    if segments.any? { |segment| segment.verses.exists? }
+      numbers = segments
+                   .order(usx_position: :asc)
+                   .flat_map { |segment| segment.verses.order(number: :asc).pluck(:number) }
+                   .uniq
+                   .sort
+      Bible::Verse.format_verse_numbers(numbers)
+    end
+  end
+
   # Returns the formatted title of the Bible section.
   #
   # The title is constructed using the book title, chapter number, and a formatted

--- a/app/models/bible/section.rb
+++ b/app/models/bible/section.rb
@@ -86,22 +86,17 @@ class Bible::Section < ApplicationRecord
 
   # Returns the formatted title of the Bible section.
   #
-  # The title is constructed using the book title, chapter number, and a formatted
-  # list of verse numbers.
+  # This method constructs the title using the book's title, the chapter number,
+  # and the verse specification. The verse specification is a formatted string
+  # representing the verse numbers associated with the section.
   #
-  # @return [String] the formatted title of the section in the format
-  #   "Book Title Chapter:FormattedVerseNumbers".
+  # @return [String, nil] The formatted title of the section in the format "Book
+  #   Title Chapter:FormattedVerseNumbers", or nil if the verse specification is
+  #   absent.
   def title
-    unformatted_verse_numbers = segments.order(usx_position: :asc).map do |segment|
-      segment.verses.order(number: :asc).map do |verse|
-        verse.number
-      end
-    end.flatten.uniq.sort!
+    return nil unless verse_spec
 
-    return "#{book.title} #{chapter.number}" if unformatted_verse_numbers.empty?
-
-    formatted_verse_numbers = Bible::Verse.format_verse_numbers unformatted_verse_numbers
-    "#{book.title} #{chapter.number}:#{formatted_verse_numbers}"
+    "#{book.title} #{chapter.number}:#{verse_spec}"
   end
 
   # Generates a structured user prompt for generating a commentary.

--- a/app/models/bible/section.rb
+++ b/app/models/bible/section.rb
@@ -61,10 +61,9 @@ class Bible::Section < ApplicationRecord
 
   # Determines if a section is ready for exposition.
   #
-  # @return [Boolean] true if any segment's USX style is a content style, false
-  # otherwise.
+  # @return [Boolean] true if the section is expositable, false otherwise.
   def expositable?
-    segments.where(usx_style: Bible::Segment::CONTENT_STYLES.map(&:to_s)).exists?
+    verse_spec.present?
   end
 
   # Generate the verse spec for the section based on the segments and their

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -73,7 +73,7 @@
                   <div class="w-full border-t border-gray-300"></div>
                 </div>
                 <div class="relative flex justify-center">
-                  <%= link_to commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, id: section.id), class: "inline-flex items-center gap-x-1.5 rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50" do %>
+                  <%= link_to commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, verse_spec: section.verse_spec), class: "inline-flex items-center gap-x-1.5 rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50" do %>
                     <svg class="-mr-0.5 -ml-1 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
                       <path d="M10.75 4.75a.75.75 0 0 0-1.5 0v4.5h-4.5a.75.75 0 0 0 0 1.5h4.5v4.5a.75.75 0 0 0 1.5 0v-4.5h4.5a.75.75 0 0 0 0-1.5h-4.5v-4.5Z" />
                     </svg>

--- a/app/views/commentary/sections/show.html.erb
+++ b/app/views/commentary/sections/show.html.erb
@@ -46,7 +46,7 @@
 </nav>
 
 <main>
-  <%= link_to  commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, id: @section.id), class: "text-blue-600 hover:text-blue-800" do %>
+  <%= link_to  commentary_book_chapter_section_path(book_slug: @book.slug, chapter_number: @chapter.number, verse_spec: @section.verse_spec), class: "text-blue-600 hover:text-blue-800" do %>
     <h1 class="text-4xl font-semibold text-pretty sm:text-5xl"><%= @section.title %></h1>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   namespace :commentary do
     resources :books, param: :slug, only: [ :index, :show ] do
       resources :chapters, param: :number, only: [ :index, :show ] do
-        resources :sections, only: [ :show ]
+        resources :sections, param: :verse_spec, only: [ :show ]
       end
     end
   end

--- a/db/migrate/20250504134402_add_verse_spec_to_bible_sections.rb
+++ b/db/migrate/20250504134402_add_verse_spec_to_bible_sections.rb
@@ -1,0 +1,5 @@
+class AddVerseSpecToBibleSections < ActiveRecord::Migration[8.0]
+  def change
+    add_column :bible_sections, :verse_spec, :string, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_135501) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_04_134402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -123,6 +123,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_135501) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "verse_spec"
     t.index ["book_id"], name: "index_bible_sections_on_book_id"
     t.index ["chapter_id"], name: "index_bible_sections_on_chapter_id"
     t.index ["heading_id"], name: "index_bible_sections_on_heading_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -145,8 +145,9 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
   chapters.each { |chapter| chapter.group_segments_in_sections!(regroup: false) }
 end
 
-# Reset counters for Bible translations, books, chapters, and verses.
+# Reset counters and set specifications for Bible translations, books, chapters, and verses.
 ResetBibleCountersJob.perform_now
+SetBibleSectionVerseSpecJob.perform_now
 
 # Restore previous logger
 Rails.logger = previous_logger if ENV["DEBUG"]

--- a/spec/models/bible/chapter_spec.rb
+++ b/spec/models/bible/chapter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bible::Chapter, type: :model do
       HEREDOC
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
       heading = FactoryBot.create(:translation_heading, translation: translation, book: book, chapter: chapter)
-      section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+      section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1, verse_spec: "1")
       segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_position: 6, usx_style: 'm')
       verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
       FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse, content: "In the beginning God created the heavens and the earth.", position: 1, show_verse: true, kind: "text")

--- a/spec/models/bible/section_spec.rb
+++ b/spec/models/bible/section_spec.rb
@@ -92,62 +92,19 @@ RSpec.describe Bible::Section, type: :model do
   end
 
   describe "#title" do
-    context "when the section has a single verse" do
+    context "when the section has a verse_spec" do
       it "returns the correct title with the verse number" do
-        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
-        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
-        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse, position: 1)
-        section.segments << segment
-        segment.verses << verse
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1, verse_spec: "1")
 
         expect(section.title).to eq "Genesis 1:1"
       end
     end
 
-    context "when the section has multiple consecutive verses" do
-      it "returns the correct title with a range of verse numbers" do
-        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
-        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
-        verse_1 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
-        verse_2 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_1, position: 1)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_2, position: 2)
-        section.segments << segment
-        segment.verses << verse_1
-        segment.verses << verse_2
-
-        expect(section.title).to eq "Genesis 1:1,2"
-      end
-    end
-
-    context "when the section has non-consecutive verses" do
-      it "returns the correct title with comma-separated verse numbers" do
-        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
-        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
-        verse_1 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
-        verse_2 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
-        verse_3 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 3)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_1, position: 1)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_2, position: 2)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_3, position: 3)
-        section.segments << segment
-        segment.verses << verse_1
-        segment.verses << verse_2
-        segment.verses << verse_3
-
-        expect(section.title).to eq "Genesis 1:1-3"
-      end
-    end
-
-    context "when the section has no verses" do
+    context "when the section has no verse_spec" do
       it "returns the book and chapter without verse numbers" do
         section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
-        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
-        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, content: "In the beginning God created the heavens and the earth.", position: 1, verse: nil)
-        section.segments << segment
 
-        expect(section.title).to eq "Genesis 1"
+        expect(section.title).to be_nil
       end
     end
   end

--- a/spec/models/bible/section_spec.rb
+++ b/spec/models/bible/section_spec.rb
@@ -30,6 +30,67 @@ RSpec.describe Bible::Section, type: :model do
     end
   end
 
+  describe "#generate_verse_spec" do
+    context "when the section has a single verse" do
+      it "returns the correct verse_spec with the verse number" do
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
+        verse = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse, position: 1)
+        section.segments << segment
+        segment.verses << verse
+
+        expect(section.generate_verse_spec).to eq "1"
+      end
+    end
+
+    context "when the section has multiple consecutive verses" do
+      it "returns the correct verse_spec with a range of verse numbers" do
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
+        verse_1 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        verse_2 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_1, position: 1)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_2, position: 2)
+        section.segments << segment
+        segment.verses << verse_1
+        segment.verses << verse_2
+
+        expect(section.generate_verse_spec).to eq "1,2"
+      end
+    end
+
+    context "when the section has non-consecutive verses" do
+      it "returns the correct verse_spec with comma-separated verse numbers" do
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
+        verse_1 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
+        verse_2 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 2)
+        verse_3 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 3)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_1, position: 1)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_2, position: 2)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, verse: verse_3, position: 3)
+        section.segments << segment
+        segment.verses << verse_1
+        segment.verses << verse_2
+        segment.verses << verse_3
+
+        expect(section.generate_verse_spec).to eq "1-3"
+      end
+    end
+
+    context "when the section has no verses" do
+      it "returns nil" do
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+        segment = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading)
+        FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment, content: "In the beginning God created the heavens and the earth.", position: 1, verse: nil)
+        section.segments << segment
+
+        expect(section.generate_verse_spec).to be_nil
+      end
+    end
+  end
+
   describe "#title" do
     context "when the section has a single verse" do
       it "returns the correct title with the verse number" do

--- a/spec/models/bible/section_spec.rb
+++ b/spec/models/bible/section_spec.rb
@@ -7,25 +7,19 @@ RSpec.describe Bible::Section, type: :model do
   let(:heading) { FactoryBot.create(:translation_heading, translation: translation, book: book, chapter: chapter) }
 
   describe "#expositable?" do
-    context "when there are no segments with a content style" do
+    context "when there is a verse_spec" do
+      it "returns true" do
+        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1, verse_spec: "1")
+
+        expect(section.expositable?).to be true
+      end
+    end
+
+    context "when there is no verse_spec" do
       it "returns false" do
         section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
 
         expect(section.expositable?).to be false
-      end
-    end
-
-    context "when at least one segment has a content style" do
-      it "returns true" do
-        section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 'h')
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 's1')
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 's2')
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 'm')
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 'pc')
-        section.segments << FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_style: 'pmo')
-
-        expect(section.expositable?).to be true
       end
     end
   end
@@ -228,14 +222,14 @@ RSpec.describe Bible::Section, type: :model do
         You are an AI providing commentary on texts from the Bible.
       HEREDOC
       # section-1
-      section_1 = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+      section_1 = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1, verse_spec: "1")
       segment_1 = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_position: 6, usx_style: 'm')
       verse_1 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 1)
       FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment_1, verse: verse_1, content: "In the beginning God created the heavens and the earth.", position: 1, show_verse: true, kind: "text")
       section_1.segments << segment_1
 
       # section-2
-      section_2 = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 2)
+      section_2 = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 2, verse_spec: "13")
       segment_2 = FactoryBot.create(:translation_segment, translation: translation, book: book, chapter: chapter, heading: heading, usx_position: 6, usx_style: 'm')
       verse_2 = FactoryBot.create(:translation_verse, translation: translation, book: book, chapter: chapter, number: 13)
       FactoryBot.create(:translation_fragment, translation: translation, book: book, chapter: chapter, heading: heading, segment: segment_2, verse: verse_2, content: "And there was evening, and there was morning—the third day.", position: 1, show_verse: true, kind: "text")

--- a/spec/requests/commentary/sections_controller_spec.rb
+++ b/spec/requests/commentary/sections_controller_spec.rb
@@ -8,14 +8,14 @@ module Commentary
       book = FactoryBot.create(:translation_book, translation: translation)
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
       heading = FactoryBot.create(:translation_heading, translation: translation, book: book, chapter: chapter)
-      section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1)
+      section = FactoryBot.create(:translation_section, translation: translation, book: book, chapter: chapter, heading: heading, position: 1, verse_spec: '1')
 
       batch_request = FactoryBot.create(:exposition_batch_request)
       system_prompt = FactoryBot.create :exposition_system_prompt
       user_prompt = FactoryBot.create :exposition_user_prompt, id: 2, batch_request: batch_request, system_prompt: system_prompt, section: section
       FactoryBot.create(:exposition_content, section: section, user_prompt: user_prompt)
 
-      get commentary_book_chapter_section_path book_slug: book.slug, chapter_number: chapter.number, id: section.id
+      get commentary_book_chapter_section_path book_slug: book.slug, chapter_number: chapter.number, verse_spec: section.verse_spec
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)

--- a/spec/routing/commentary/sections_spec.rb
+++ b/spec/routing/commentary/sections_spec.rb
@@ -3,8 +3,16 @@ require 'rails_helper'
 module Commentary
   RSpec.describe SectionsController, type: :routing do
     describe 'routing' do
-      it 'routes GET /commentary/books/:book_slug/chapters/:chapter_number/sections/:id to #show' do
-        expect(get: '/commentary/books/genesis/chapters/1/sections/1').to route_to('commentary/sections#show', book_slug: 'genesis', chapter_number: '1', id: '1')
+      it 'routes GET /commentary/books/:book_slug/chapters/:chapter_number/sections/:verse_spec to #show' do
+        expect(get: '/commentary/books/genesis/chapters/1/sections/1').to route_to('commentary/sections#show', book_slug: 'genesis', chapter_number: '1', verse_spec: '1')
+      end
+
+      it 'routes GET /commentary/books/:book_slug/chapters/:chapter_number/sections/:verse_spec to #show' do
+        expect(get: '/commentary/books/genesis/chapters/1/sections/1,2').to route_to('commentary/sections#show', book_slug: 'genesis', chapter_number: '1', verse_spec: '1,2')
+      end
+
+      it 'routes GET /commentary/books/:book_slug/chapters/:chapter_number/sections/:verse_spec to #show' do
+        expect(get: '/commentary/books/genesis/chapters/1/sections/1-3').to route_to('commentary/sections#show', book_slug: 'genesis', chapter_number: '1', verse_spec: '1-3')
       end
     end
   end


### PR DESCRIPTION
This pull request introduces a new `verse_spec` attribute for Bible sections, replacing the previous `id` parameter in URLs and enhancing the functionality for managing and displaying Bible sections. The most important changes include updating the `Bible::Section` model to support `verse_spec`, modifying controllers and views to use this new parameter, and adding a background job to populate `verse_spec` values for existing sections.

> [!IMPORTANT]
> Rolling out this change requires the following actions to be done pre-deployment:
> 
> 1. Run migrations with `bundle exec rails db:migrate`.
> 1. Backfill `Bible::Section#verse_spec` by running `SetBibleSectionVerseSpecJob`.

### Changes

#### Model and Database Updates

* Added a new `verse_spec` column to the `bible_sections` table, allowing sections to be identified by a formatted string of verse numbers instead of an `id`.
* Updated the `Bible::Section` model to include a `generate_verse_spec` method for creating `verse_spec` values and a `scope :expositable` to filter sections with non-nil `verse_spec`.

#### Controller and Routing Changes

* Modified `SectionsController` to use `verse_spec` instead of `id` for fetching sections.
* Updated routes to use `verse_spec` as the parameter for sections.

#### Background Job

* Introduced `SetBibleSectionVerseSpecJob` to populate `verse_spec` for existing sections, ensuring backward compatibility and seamless migration.

#### View and URL Updates

* Updated views to use `verse_spec` in URLs, ensuring consistent navigation and display.

#### Test Updates

* Adjusted model and controller tests to account for the new `verse_spec` attribute, ensuring proper validation and functionality.